### PR TITLE
Form encoded contenttype

### DIFF
--- a/lib/sequences/03_patient_standalone_launch_sequence.rb
+++ b/lib/sequences/03_patient_standalone_launch_sequence.rb
@@ -114,11 +114,11 @@ class PatientStandaloneLaunchSequence < SequenceBase
     if @instance.confidential_client
       oauth2_headers = {
           'Authorization' => "Basic #{Base64.strict_encode64(@instance.client_id + ':' + @instance.client_secret)}",
-          'Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded'
+          'Content-Type' => 'application/x-www-form-urlencoded'
       }
     else
       oauth2_params['client_id'] = @instance.client_id
-      oauth2_headers = { 'Accept' => 'application/json', 'Content-Type' => 'application/x-www-form-urlencoded' }
+      oauth2_headers = { 'Content-Type' => 'application/x-www-form-urlencoded' }
     end
     @token_response = LoggedRestClient.post(@instance.oauth_token_endpoint, oauth2_params, oauth2_headers)
     assert_response_ok(@token_response)

--- a/lib/utils/logged_rest_client.rb
+++ b/lib/utils/logged_rest_client.rb
@@ -29,7 +29,8 @@ class LoggedRestClient
       payload: payload
     }
 
-    request[:payload] = URI.encode_www_form(payload) if payload.is_a?(Hash)
+    #request[:payload] = URI.encode_www_form(payload) if payload.is_a?(Hash)
+    request[:payload] = payload.to_json if payload.is_a?(Hash)
     self.record_response(request, reply)
     return reply
   end
@@ -72,7 +73,8 @@ class LoggedRestClient
       payload: payload
     }
 
-    request[:payload] = URI.encode_www_form(payload) if payload.is_a?(Hash)
+    #request[:payload] = URI.encode_www_form(payload) if payload.is_a?(Hash)
+    request[:payload] = payload.to_json if payload.is_a?(Hash)
     self.record_response(request, reply)
     return reply
   end
@@ -86,7 +88,8 @@ class LoggedRestClient
       payload: payload
     }
 
-    request[:payload] = URI.encode_www_form(payload) if payload.is_a?(Hash)
+    #request[:payload] = URI.encode_www_form(payload) if payload.is_a?(Hash)
+    request[:payload] = payload.to_json if payload.is_a?(Hash)
     self.record_response(request, reply)
     return reply
   end
@@ -100,7 +103,8 @@ class LoggedRestClient
       payload: payload
     }
 
-    request[:payload] = URI.encode_www_form(payload) if payload.is_a?(Hash)
+    #request[:payload] = URI.encode_www_form(payload) if payload.is_a?(Hash)
+    request[:payload] = payload.to_json if payload.is_a?(Hash)
     self.record_response(request, reply)
     return reply
   end


### PR DESCRIPTION
FYI @radamson.  Turns out I had a bad assumption about the headers getting overwritten with the right values.  Turns out we aren't doing a good job of representing what is actually getting sent from RestClient.  There should be a better solution than what we are doing now...

BTW it was the tests that caused me to notice this, because the webmocks weren't capturing the requests because they were expecting the proper headers to be specified.  Glad we have those tests.

Also, we really should be representing www-encoded form data as url-encoded strings.  I attempted to do that but still got the 'null' problem, so I commented it out for now.  But we really should figure this out.

I'm going to go ahead and merge this because we weren't spec compliant before with the wrong header (just turns out our test server was lenient with this).  But we should be doing a better job with RestClient.